### PR TITLE
Fix cypher errors for Airbnb and IoT

### DIFF
--- a/airbnb/src/import/import.cypher
+++ b/airbnb/src/import/import.cypher
@@ -155,13 +155,13 @@ ON MATCH SET l.count = coalesce(l.count, 0) + 1
 // Location hierarchy
 MERGE (n:Neighborhood {neighborhood_id: coalesce(row.neighbourhood_cleansed, "NA")})
 SET n.name = row.neighbourhood
-MERGE (c:City {citystate: row.city + "-" + row.state})
+MERGE (c:City {citystate: coalesce(row.city + "-" + row.state, "NA")})
 ON CREATE SET c.name = row.city
 MERGE (l)-[:IN_NEIGHBORHOOD]->(n)
 MERGE (n)-[:LOCATED_IN]->(c)
-MERGE (s:State {code: row.state})
+MERGE (s:State {code: coalesce(row.state, "NA")})
 MERGE (c)-[:IN_STATE]->(s)
-MERGE (country:Country {code: row.country_code})
+MERGE (country:Country {code: coalesce(row.country_code, "NA")})
 SET country.name = row.country
 MERGE (s)-[:IN_COUNTRY]->(country)
 

--- a/iot/src/import/import.cypher
+++ b/iot/src/import/import.cypher
@@ -28,4 +28,4 @@ FOREACH (_ IN CASE WHEN row.City IS NOT NULL AND row.Country IS NOT NULL THEN [1
 FOREACH (_ IN CASE WHEN row.Country IS NOT NULL AND row.City IS NULL THEN [1] ELSE [] END |
     MERGE (country:Country {name: row.Country})
     MERGE (ip)-[:IN_COUNTRY]->(country)
-)
+);


### PR DESCRIPTION
PR aims to fix the following issues:
- Some cities in Airbnb dataset have missing fields for columns `state` and `country`.
- Missing semicolon in IoT dataset cypher script which makes `cypher shell` ignore the statement.